### PR TITLE
Gossip with failure domains

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,9 +1,10 @@
 package gossip
 
 import (
+	"time"
+
 	"github.com/libopenstorage/gossip/proto"
 	"github.com/libopenstorage/gossip/types"
-	"time"
 )
 
 type GossipStore interface {
@@ -48,7 +49,7 @@ type GossipStore interface {
 	GetLocalNodeInfo(types.NodeId) (types.NodeInfo, error)
 
 	// Add a new node in the database
-	AddNode(types.NodeId, types.NodeStatus, bool)
+	AddNode(types.NodeId, types.NodeStatus, bool, string)
 
 	// Remove a node from the database
 	RemoveNode(types.NodeId) error
@@ -60,7 +61,7 @@ type Gossiper interface {
 
 	// Start begins the gossip protocol using memberlist
 	// To join an existing cluster provide atleast one ip of the known node.
-	Start(knownIp []string) error
+	Start(knownIp []string, activeFailureDomain string) error
 
 	// GossipInterval gets the gossip interval
 	GossipInterval() time.Duration
@@ -79,6 +80,14 @@ type Gossiper interface {
 	// It checks quorum and appropriately marks either self down or the other node down.
 	// It returns the nodeId that was marked down
 	ExternalNodeLeave(nodeId types.NodeId) types.NodeId
+
+	// MarkActiveFailureDomain marks a specific failure domain which gossip nodes
+	// are aware of as the active one. All the nodes in other failure domains which
+	// cannot reach the active failure domain will shoot themselves down
+	MarkActiveFailureDomain(activeFailureDomain string)
+
+	// UpdateSelfFailureDomain updates this node's failure domain
+	UpdateSelfFailureDomain(selfFailureDomain string)
 }
 
 // New returns an initialized Gossip node

--- a/proto/gossip_delegates.go
+++ b/proto/gossip_delegates.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/hashicorp/memberlist"
+	"github.com/sirupsen/logrus"
 
 	"github.com/libopenstorage/gossip/proto/state"
 	"github.com/libopenstorage/gossip/types"
@@ -54,7 +54,7 @@ func (gd *GossipDelegate) InitGossipDelegate(
 func (gd *GossipDelegate) InitCurrentState(clusterSize uint) {
 	// Our initial state is NOT_IN_QUORUM
 	gd.currentState = state.GetNotInQuorum(
-		uint(clusterSize), types.NodeId(gd.nodeId), gd.stateEvent)
+		uint(clusterSize), types.NodeId(gd.nodeId), gd.stateEvent, gd.getActiveFailureDomain())
 	// Start the go routine which handles all the events
 	// and changes state of the node
 	go gd.handleStateEvents()
@@ -305,6 +305,11 @@ func (gd *GossipDelegate) handleStateEvents() {
 		case types.UPDATE_CLUSTER_SIZE:
 			gd.currentState, _ = gd.currentState.UpdateClusterSize(
 				gd.getNumQuorumMembers(), gd.GetLocalState())
+		case types.MARK_ACTIVE_FAILURE_DOMAIN:
+			gd.currentState, _ = gd.currentState.MarkActiveFailureDomain(
+				gd.getActiveFailureDomain(),
+				gd.GetLocalState(),
+			)
 		case types.TIMEOUT:
 			newState, _ := gd.currentState.Timeout(
 				gd.getNumQuorumMembers(), gd.GetLocalState())

--- a/proto/gossip_quorom_test.go
+++ b/proto/gossip_quorom_test.go
@@ -1,10 +1,11 @@
 package proto
 
 import (
-	"github.com/libopenstorage/gossip/types"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/libopenstorage/gossip/types"
 )
 
 const DEFAULT_CLUSTER_ID = "test-cluster"
@@ -42,7 +43,7 @@ func TestQuorumAllNodesUpOneByOne(t *testing.T) {
 	node0 := types.NodeId("0")
 	g0, _ := startNode(t, nodes[0], node0, []string{},
 		map[types.NodeId]types.NodeUpdate{
-			node0: types.NodeUpdate{nodes[0], true}})
+			node0: types.NodeUpdate{nodes[0], true, ""}})
 
 	time.Sleep(g0.GossipInterval())
 	status := g0.GetSelfStatus()
@@ -54,8 +55,8 @@ func TestQuorumAllNodesUpOneByOne(t *testing.T) {
 	// Start Node1 with cluster size 2
 	node1 := types.NodeId("1")
 	peers := map[types.NodeId]types.NodeUpdate{
-		node0: types.NodeUpdate{nodes[0], true},
-		node1: types.NodeUpdate{nodes[1], true}}
+		node0: types.NodeUpdate{nodes[0], true, ""},
+		node1: types.NodeUpdate{nodes[1], true, ""}}
 	g1, _ := startNode(t, nodes[1], node1, []string{nodes[0]}, peers)
 	g0.UpdateCluster(peers)
 
@@ -87,7 +88,7 @@ func TestQuorumNodeLoosesQuorumAndGainsBack(t *testing.T) {
 	// Start Node 0
 	g0, _ := startNode(t, nodes[0], node0, []string{},
 		map[types.NodeId]types.NodeUpdate{
-			node0: types.NodeUpdate{nodes[0], true}})
+			node0: types.NodeUpdate{nodes[0], true, ""}})
 
 	time.Sleep(g0.GossipInterval())
 	selfStatus := g0.GetSelfStatus()
@@ -99,8 +100,8 @@ func TestQuorumNodeLoosesQuorumAndGainsBack(t *testing.T) {
 	// Simulate new node was added by updating the cluster size, but the new node is not talking to node0
 	// Node 0 should loose quorom 1/2
 	g0.UpdateCluster(map[types.NodeId]types.NodeUpdate{
-		node0: types.NodeUpdate{nodes[0], true},
-		node1: types.NodeUpdate{nodes[1], true}})
+		node0: types.NodeUpdate{nodes[0], true, ""},
+		node1: types.NodeUpdate{nodes[1], true, ""}})
 	time.Sleep(g0.GossipInterval() * time.Duration(len(nodes)+1))
 	selfStatus = g0.GetSelfStatus()
 	if selfStatus != types.NODE_STATUS_SUSPECT_NOT_IN_QUORUM {
@@ -120,8 +121,8 @@ func TestQuorumNodeLoosesQuorumAndGainsBack(t *testing.T) {
 	// Lets start the actual Node 1
 	g1, _ := startNode(t, nodes[1], node1, []string{nodes[0]},
 		map[types.NodeId]types.NodeUpdate{
-			node0: types.NodeUpdate{nodes[0], true},
-			node1: types.NodeUpdate{nodes[1], true}})
+			node0: types.NodeUpdate{nodes[0], true, ""},
+			node1: types.NodeUpdate{nodes[1], true, ""}})
 
 	// Sleep so that nodes gossip
 	time.Sleep(g1.GossipInterval() * time.Duration(len(nodes)+1))
@@ -150,7 +151,7 @@ func TestQuorumTwoNodesLooseConnectivity(t *testing.T) {
 	node1 := types.NodeId("1")
 	g0, _ := startNode(t, nodes[0], node0, []string{},
 		map[types.NodeId]types.NodeUpdate{
-			node0: types.NodeUpdate{nodes[0], true}})
+			node0: types.NodeUpdate{nodes[0], true, ""}})
 
 	time.Sleep(g0.GossipInterval())
 	if g0.GetSelfStatus() != types.NODE_STATUS_UP {
@@ -160,8 +161,8 @@ func TestQuorumTwoNodesLooseConnectivity(t *testing.T) {
 	// Simulate new node was added by updating the cluster size, but the new node is not talking to node0
 	// Node 0 should loose quorom 1/2
 	g0.UpdateCluster(map[types.NodeId]types.NodeUpdate{
-		node0: types.NodeUpdate{nodes[0], true},
-		node1: types.NodeUpdate{nodes[1], true}})
+		node0: types.NodeUpdate{nodes[0], true, ""},
+		node1: types.NodeUpdate{nodes[1], true, ""}})
 	time.Sleep(g0.GossipInterval() * time.Duration(len(nodes)+1))
 	if g0.GetSelfStatus() != types.NODE_STATUS_SUSPECT_NOT_IN_QUORUM {
 		t.Error("Expected Node 0 to have status: ", types.NODE_STATUS_SUSPECT_NOT_IN_QUORUM)
@@ -171,8 +172,8 @@ func TestQuorumTwoNodesLooseConnectivity(t *testing.T) {
 	// to simulate NO connectivity between node 0 and node 1
 	g1, _ := startNode(t, nodes[1], node1, []string{},
 		map[types.NodeId]types.NodeUpdate{
-			node0: types.NodeUpdate{nodes[0], true},
-			node1: types.NodeUpdate{nodes[1], true}})
+			node0: types.NodeUpdate{nodes[0], true, ""},
+			node1: types.NodeUpdate{nodes[1], true, ""}})
 
 	// For node 0 the status will change from UP_WAITING_QUORUM to WAITING_QUORUM after
 	// the quorum timeout
@@ -223,7 +224,7 @@ func TestQuorumOneNodeIsolated(t *testing.T) {
 	// but by not providing peer IPs and setting cluster size to 3.
 	gossipers[1].Stop(time.Duration(10) * time.Second)
 	gossipers[1].InitStore(types.NodeId("1"), "v1", types.NODE_STATUS_NOT_IN_QUORUM, DEFAULT_CLUSTER_ID)
-	gossipers[1].Start([]string{})
+	gossipers[1].Start([]string{}, "")
 
 	// Lets sleep so that the nodes gossip and update their quorum
 	time.Sleep(types.DEFAULT_GOSSIP_INTERVAL * time.Duration(len(nodes)+1))
@@ -260,7 +261,7 @@ func TestQuorumNetworkPartition(t *testing.T) {
 		g, _ = startNode(t, nodes[i], nodeId,
 			[]string{nodes[0], nodes[1], nodes[2]},
 			map[types.NodeId]types.NodeUpdate{
-				nodeId: types.NodeUpdate{nodes[i], true}})
+				nodeId: types.NodeUpdate{nodes[i], true, ""}})
 		gossipers = append(gossipers, g)
 	}
 	// Parition 2
@@ -269,7 +270,7 @@ func TestQuorumNetworkPartition(t *testing.T) {
 		var g *GossiperImpl
 		g, _ = startNode(t, nodes[i], nodeId, []string{nodes[3], nodes[4]},
 			map[types.NodeId]types.NodeUpdate{
-				nodeId: types.NodeUpdate{nodes[i], true}})
+				nodeId: types.NodeUpdate{nodes[i], true, ""}})
 		gossipers = append(gossipers, g)
 	}
 	// Let the nodes gossip
@@ -329,7 +330,7 @@ func TestQuorumEventHandling(t *testing.T) {
 		var g *GossiperImpl
 		g, _ = startNode(t, nodes[i], nodeId, []string{nodes[0]},
 			map[types.NodeId]types.NodeUpdate{
-				nodeId: types.NodeUpdate{nodes[0], true}})
+				nodeId: types.NodeUpdate{nodes[0], true, ""}})
 		gossipers = append(gossipers, g)
 	}
 
@@ -369,7 +370,7 @@ func TestQuorumEventHandling(t *testing.T) {
 	}
 
 	// Start Node 2
-	gossipers[2].Start([]string{nodes[0]})
+	gossipers[2].Start([]string{nodes[0]}, "")
 	gossipers[2].UpdateCluster(peers)
 
 	time.Sleep(types.DEFAULT_GOSSIP_INTERVAL)
@@ -390,7 +391,7 @@ func TestQuorumEventHandling(t *testing.T) {
 	}
 
 	// Start Node 1
-	gossipers[1].Start([]string{nodes[0]})
+	gossipers[1].Start([]string{nodes[0]}, "")
 	gossipers[1].UpdateCluster(peers)
 
 	time.Sleep(time.Duration(2) * types.DEFAULT_GOSSIP_INTERVAL)
@@ -467,7 +468,7 @@ func TestQuorumAddNodes(t *testing.T) {
 	node0Ip := "127.0.0.1:9923"
 	node0 := types.NodeId("0")
 	peers := make(map[types.NodeId]types.NodeUpdate)
-	peers[node0] = types.NodeUpdate{node0Ip, true}
+	peers[node0] = types.NodeUpdate{node0Ip, true, ""}
 	g0, _ := startNode(t, node0Ip, node0, []string{}, peers)
 
 	// Lets sleep so that the nodes gossip and update their quorum
@@ -481,7 +482,7 @@ func TestQuorumAddNodes(t *testing.T) {
 	// Add a new node
 	node1 := types.NodeId("1")
 	node1Ip := "127.0.0.2:9924"
-	peers[node1] = types.NodeUpdate{node1Ip, true}
+	peers[node1] = types.NodeUpdate{node1Ip, true, ""}
 	g0.UpdateCluster(peers)
 
 	time.Sleep(types.DEFAULT_GOSSIP_INTERVAL)
@@ -546,7 +547,7 @@ func TestNonQuorumMembersAddRemove(t *testing.T) {
 	for i, node := range newNodes {
 		quorumMember := i != 0
 		nodeId := types.NodeId(strconv.Itoa(len(peers)))
-		peers[nodeId] = types.NodeUpdate{node, quorumMember}
+		peers[nodeId] = types.NodeUpdate{node, quorumMember, ""}
 		for _, g := range gossipers {
 			g.UpdateCluster(peers)
 		}

--- a/proto/gossip_store_test.go
+++ b/proto/gossip_store_test.go
@@ -2,12 +2,13 @@ package proto
 
 import (
 	"fmt"
-	"github.com/libopenstorage/gossip/types"
 	"math/rand"
 	"runtime"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/libopenstorage/gossip/types"
 )
 
 const (
@@ -235,7 +236,7 @@ func TestGossipStoreUpdateData(t *testing.T) {
 	diff = make(types.NodeInfoMap)
 	nodeLen := 5
 	for i := 0; i < nodeLen; i++ {
-		g.AddNode(types.NodeId(strconv.Itoa(i)), types.NODE_STATUS_UP, true)
+		g.AddNode(types.NodeId(strconv.Itoa(i)), types.NODE_STATUS_UP, true, "")
 	}
 	keyList := []types.StoreKey{"key1", "key2", "key3", "key4", "key5"}
 	for _, key := range keyList {

--- a/proto/gossip_test.go
+++ b/proto/gossip_test.go
@@ -1,12 +1,13 @@
 package proto
 
 import (
-	"github.com/libopenstorage/gossip/types"
 	"math/rand"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/libopenstorage/gossip/types"
 )
 
 const (
@@ -26,7 +27,7 @@ func newGossiperImpl(ip string, selfNodeId types.NodeId, knownIps []string, vers
 	}
 	g.Init(ip, selfNodeId, 1, gi, version, clusterId)
 	g.selfCorrect = false
-	err := g.Start(knownIps)
+	err := g.Start(knownIps, "")
 	return g, err
 }
 
@@ -53,7 +54,7 @@ func getNodeUpdateMap(nodesIp []string) map[types.NodeId]types.NodeUpdate {
 	peers := make(map[types.NodeId]types.NodeUpdate)
 	for i, ip := range nodesIp {
 		nodeId := types.NodeId(strconv.FormatInt(int64(i), 10))
-		peers[nodeId] = types.NodeUpdate{ip, true}
+		peers[nodeId] = types.NodeUpdate{ip, true, ""}
 	}
 	return peers
 }
@@ -380,9 +381,9 @@ func TestGossiperGroupingOfNodesWithSameVersion(t *testing.T) {
 	for i, ip := range nodes {
 		nodeId := types.NodeId(strconv.FormatInt(int64(i), 10))
 		if i != 0 && i%2 == 0 {
-			peers2[nodeId] = types.NodeUpdate{ip, true}
+			peers2[nodeId] = types.NodeUpdate{ip, true, ""}
 		} else {
-			peers1[nodeId] = types.NodeUpdate{ip, true}
+			peers1[nodeId] = types.NodeUpdate{ip, true, ""}
 		}
 	}
 
@@ -721,7 +722,7 @@ func TestGossiperAddNodeExternally(t *testing.T) {
 	}
 
 	nodes = append(nodes, "127.0.0.3:9160")
-	peers[types.NodeId("2")] = types.NodeUpdate{nodes[2], true}
+	peers[types.NodeId("2")] = types.NodeUpdate{nodes[2], true, ""}
 
 	for _, g := range gossipers {
 		g.UpdateCluster(peers)
@@ -938,9 +939,9 @@ func TestGossiperNodesWithDifferentClusterId(t *testing.T) {
 	for i, ip := range nodes {
 		nodeId := types.NodeId(strconv.FormatInt(int64(i), 10))
 		if i == 2 || i == 4 {
-			peers2[nodeId] = types.NodeUpdate{ip, true}
+			peers2[nodeId] = types.NodeUpdate{ip, true, ""}
 		} else {
-			peers1[nodeId] = types.NodeUpdate{ip, true}
+			peers1[nodeId] = types.NodeUpdate{ip, true, ""}
 		}
 	}
 

--- a/proto/state/state.go
+++ b/proto/state/state.go
@@ -31,6 +31,14 @@ type State interface {
 		nodeInfoMap types.NodeInfoMap,
 	) (State, error)
 
+	// MarkActiveFailureDomain is an event triggered from an external entity indicating
+	// which is the active failure domain. All the nodes in that failure domain will remain online
+	// even if they are out of quorum, while nodes from other domains will shoot themselves
+	MarkActiveFailureDomain(
+		activeFailureDomain string,
+		nodeInfoMap types.NodeInfoMap,
+	) (State, error)
+
 	// Timeout is an event triggered when quorum timeout has reached
 	Timeout(
 		numQuorumMembers uint,

--- a/proto/state/state_down.go
+++ b/proto/state/state_down.go
@@ -5,22 +5,25 @@ import (
 )
 
 type down struct {
-	nodeStatus       types.NodeStatus
-	id               types.NodeId
-	numQuorumMembers uint
-	stateEvent       chan types.StateEvent
+	nodeStatus          types.NodeStatus
+	id                  types.NodeId
+	numQuorumMembers    uint
+	stateEvent          chan types.StateEvent
+	activeFailureDomain string
 }
 
 func GetDown(
 	numQuorumMembers uint,
 	selfId types.NodeId,
 	stateEvent chan types.StateEvent,
+	activeFailureDomain string,
 ) State {
 	return &down{
-		nodeStatus:       types.NODE_STATUS_DOWN,
-		numQuorumMembers: numQuorumMembers,
-		id:               selfId,
-		stateEvent:       stateEvent,
+		nodeStatus:          types.NODE_STATUS_DOWN,
+		numQuorumMembers:    numQuorumMembers,
+		id:                  selfId,
+		stateEvent:          stateEvent,
+		activeFailureDomain: activeFailureDomain,
 	}
 }
 
@@ -51,6 +54,13 @@ func (d *down) NodeLeave(localNodeInfoMap types.NodeInfoMap) (State, error) {
 func (d *down) UpdateClusterSize(
 	numQuorumMembers uint,
 	localNodeInfoMap types.NodeInfoMap,
+) (State, error) {
+	return d, nil
+}
+
+func (d *down) MarkActiveFailureDomain(
+	activeFailureDomain string,
+	localNodeInfo types.NodeInfoMap,
 ) (State, error) {
 	return d, nil
 }

--- a/proto/state/state_up.go
+++ b/proto/state/state_up.go
@@ -5,22 +5,25 @@ import (
 )
 
 type up struct {
-	nodeStatus       types.NodeStatus
-	id               types.NodeId
-	numQuorumMembers uint
-	stateEvent       chan types.StateEvent
+	nodeStatus          types.NodeStatus
+	id                  types.NodeId
+	numQuorumMembers    uint
+	stateEvent          chan types.StateEvent
+	activeFailureDomain string
 }
 
 func GetUp(
 	numQuorumMembers uint,
 	selfId types.NodeId,
 	stateEvent chan types.StateEvent,
+	activeFailureDomain string,
 ) State {
 	return &up{
-		nodeStatus:       types.NODE_STATUS_UP,
-		numQuorumMembers: numQuorumMembers,
-		id:               selfId,
-		stateEvent:       stateEvent,
+		nodeStatus:          types.NODE_STATUS_UP,
+		numQuorumMembers:    numQuorumMembers,
+		id:                  selfId,
+		stateEvent:          stateEvent,
+		activeFailureDomain: activeFailureDomain,
 	}
 }
 
@@ -41,29 +44,71 @@ func (u *up) NodeAlive(localNodeInfoMap types.NodeInfoMap) (State, error) {
 }
 
 func (u *up) SelfLeave() (State, error) {
-	down := GetDown(u.numQuorumMembers, u.id, u.stateEvent)
+	down := GetDown(u.numQuorumMembers, u.id, u.stateEvent, u.activeFailureDomain)
 	return down, nil
 }
 
-func numQuorumMembersUp(localNodeInfoMap types.NodeInfoMap) uint {
+func isNodeInQuorum(
+	localNodeInfoMap types.NodeInfoMap,
+	selfId types.NodeId,
+	totalNumOfQuorumMembers uint,
+	activeFailureDomain string,
+) bool {
 	upNodes := uint(0)
+	selfNodeInfo := localNodeInfoMap[selfId]
+	selfDomain := selfNodeInfo.FailureDomain
+
+	if len(activeFailureDomain) > 0 && (selfDomain != activeFailureDomain) {
+		// If there is an active failure domain, shoot ourselves down
+		// if we are not part of that failure domain
+		return false
+	}
+
+	totalNodesInActiveDomain := 0
+	upNodesInActiveDomain := 0
 	for _, nodeInfo := range localNodeInfoMap {
-		if nodeInfo.QuorumMember &&
-			(nodeInfo.Status == types.NODE_STATUS_UP ||
+		if nodeInfo.QuorumMember {
+
+			if len(activeFailureDomain) > 0 &&
+				(nodeInfo.FailureDomain == activeFailureDomain) {
+				// update the total nodes in active domain
+				totalNodesInActiveDomain++
+			}
+
+			if nodeInfo.Status == types.NODE_STATUS_UP ||
 				nodeInfo.Status == types.NODE_STATUS_NOT_IN_QUORUM ||
-				nodeInfo.Status == types.NODE_STATUS_SUSPECT_NOT_IN_QUORUM) {
-			upNodes++
+				nodeInfo.Status == types.NODE_STATUS_SUSPECT_NOT_IN_QUORUM {
+				// update the total no. of up nodes
+				upNodes++
+
+				// update the total no. of up nodes in an active domain
+				if nodeInfo.FailureDomain == activeFailureDomain {
+					upNodesInActiveDomain++
+				}
+			}
 		}
 	}
-	return upNodes
+
+	// Check if we are in quorum
+	if len(activeFailureDomain) > 0 {
+		quorumCount := (totalNodesInActiveDomain / 2) + 1
+		if upNodesInActiveDomain >= quorumCount {
+			return true
+		}
+	} else {
+		quorumCount := (totalNumOfQuorumMembers / 2) + 1
+		if upNodes >= quorumCount {
+			return true
+		}
+	}
+	// We are out of quorum
+	return false
 }
 
 func (u *up) NodeLeave(localNodeInfoMap types.NodeInfoMap) (State, error) {
-	quorum := (u.numQuorumMembers / 2) + 1
-	upNodes := numQuorumMembersUp(localNodeInfoMap)
-	if upNodes < quorum {
+	if !isNodeInQuorum(localNodeInfoMap, u.id, u.numQuorumMembers, u.activeFailureDomain) {
 		// Caller of this function should start a timer
-		return GetSuspectNotInQuorum(u.numQuorumMembers, u.id, u.stateEvent), nil
+		return GetSuspectNotInQuorum(u.numQuorumMembers, u.id, u.stateEvent, u.activeFailureDomain), nil
 	} else {
 		return u, nil
 	}
@@ -74,11 +119,22 @@ func (u *up) UpdateClusterSize(
 	localNodeInfoMap types.NodeInfoMap,
 ) (State, error) {
 	u.numQuorumMembers = numQuorumMembers
-	quorum := (u.numQuorumMembers / 2) + 1
-	upNodes := numQuorumMembersUp(localNodeInfoMap)
-	if upNodes < quorum {
+	if !isNodeInQuorum(localNodeInfoMap, u.id, u.numQuorumMembers, u.activeFailureDomain) {
 		// Caller of this function should start a timer
-		return GetSuspectNotInQuorum(u.numQuorumMembers, u.id, u.stateEvent), nil
+		return GetSuspectNotInQuorum(u.numQuorumMembers, u.id, u.stateEvent, u.activeFailureDomain), nil
+	} else {
+		return u, nil
+	}
+}
+
+func (u *up) MarkActiveFailureDomain(
+	activeFailureDomain string,
+	localNodeInfoMap types.NodeInfoMap,
+) (State, error) {
+	u.activeFailureDomain = activeFailureDomain
+	if !isNodeInQuorum(localNodeInfoMap, u.id, u.numQuorumMembers, u.activeFailureDomain) {
+		// Caller of this function should start a timer
+		return GetSuspectNotInQuorum(u.numQuorumMembers, u.id, u.stateEvent, u.activeFailureDomain), nil
 	} else {
 		return u, nil
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -41,6 +41,7 @@ const (
 	NODE_LEAVE
 	UPDATE_CLUSTER_SIZE
 	TIMEOUT
+	MARK_ACTIVE_FAILURE_DOMAIN
 )
 
 type NodeUpdate struct {
@@ -48,6 +49,8 @@ type NodeUpdate struct {
 	Addr string
 	// QuorumMember is true if node participates in quorum decisions
 	QuorumMember bool
+	// FailureDomain of the node
+	FailureDomain string
 }
 
 type NodeMetaInfo struct {
@@ -66,6 +69,8 @@ type NodeInfo struct {
 	Status             NodeStatus
 	Value              StoreMap
 	QuorumMember       bool
+	// FailureDomain indicates the failure domain in which this node lies
+	FailureDomain string
 }
 
 type NodeValue struct {


### PR DESCRIPTION
Node behavior with failure domains
 - Each node will be tagged with a failure domain.
 - Callers of gossip are expected to pass in the failure domains
 - A new API UpdateSelfFailureDomain added to update the failure domain on the fly.
 - An empty failure domain is treated as if there are no failure domains.

Cluster behavior with failure domains
 - If no failure domains are set the behavior of gossip remains the same
 - Added a new API MarkActiveFailureDomain
 - If a failure domain is marked active, all the nodes which are not a part of the failure
   domain will shoot themselves down and stay out of quorum until the active domain is deactivated.
 - Once a failure domain is active, the quorum calculations will be done considering only the nodes
   which are a part of that failure domain.

- The domain information and active domain information should come from a persistence store like kvdb.

TODOs:
 - Currently MarkActiveFailureDomain is used for activating and deactivating a failure domain.
 - The API only takes in one failure domain as an input, assuming that there are only two failure domains,
   Need to extend this API to handle a list of failure domains to activate.
- Add UTs with failure domains