### PR TITLE
Start/Stop gossiping based on the domain's active state.

### DIFF
--- a/proto/gossip_delegates.go
+++ b/proto/gossip_delegates.go
@@ -434,6 +434,11 @@ func (gd *GossipDelegate) isClusterDomainSuspectDown(nodeId types.NodeId) bool {
 		// We will mark it as Offline immediately
 		return false
 	}
+	if !gd.quorumProvider.IsDomainActive(nodeInfo.ClusterDomain) {
+		// The node is already a part of inactive domain
+		// No need of putting it as a suspect
+		return false
+	}
 	nodeList := gd.getNodesFromClusterDomain(nodeInfo.ClusterDomain)
 	for fdNodeId, _ := range nodeList {
 		if fdNodeId == nodeId || types.NodeId(gd.nodeId) == nodeId {

--- a/proto/state/quorum.go
+++ b/proto/state/quorum.go
@@ -16,6 +16,8 @@ type Quorum interface {
 	// UpdateClusterDomainsActiveMap updates the map of active and inactive failure
 	// domains. It returns a boolean value indicating if an update was done
 	UpdateClusterDomainsActiveMap(activeMap types.ClusterDomainsActiveMap) bool
+	// IsDomainActive returns true if the domain is active
+	IsDomainActive(selfDomain string) bool
 	// Type returns the type of quorum implementation
 	Type() types.QuorumProvider
 }
@@ -56,6 +58,11 @@ func (d *defaultQuorum) IsNodeInQuorum(localNodeInfoMap types.NodeInfoMap) bool 
 	}
 	quorum := (d.numQuorumMembers / 2) + 1
 	return upNodes >= quorum
+}
+
+func (d *defaultQuorum) IsDomainActive(ipDomain string) bool {
+	// When no cluster domains are set, then the nodes are always active
+	return true
 }
 
 func (d *defaultQuorum) UpdateNumOfQuorumMembers(quorumMemberMap types.ClusterDomainsQuorumMembersMap) {

--- a/proto/state/quorum_failure_domains.go
+++ b/proto/state/quorum_failure_domains.go
@@ -23,7 +23,7 @@ func (f *failureDomainsQuorum) IsNodeInQuorum(localNodeInfoMap types.NodeInfoMap
 	selfNodeInfo := localNodeInfoMap[f.selfId]
 	selfDomain := selfNodeInfo.ClusterDomain
 
-	if !f.isNodeActive(selfDomain) {
+	if !f.isDomainActive(selfDomain) {
 		// This node is a part of deactivated failure domain
 		// Shoot ourselves down as we are not in quorum
 		return false
@@ -41,7 +41,7 @@ func (f *failureDomainsQuorum) IsNodeInQuorum(localNodeInfoMap types.NodeInfoMap
 
 	for _, nodeInfo := range localNodeInfoMap {
 		if nodeInfo.QuorumMember {
-			if !f.isNodeActive(nodeInfo.ClusterDomain) {
+			if !f.isDomainActive(nodeInfo.ClusterDomain) {
 				// node is not a part of active domain
 				// do not consider in quorum calculations
 				continue
@@ -60,12 +60,18 @@ func (f *failureDomainsQuorum) IsNodeInQuorum(localNodeInfoMap types.NodeInfoMap
 	return upNodesInActiveDomains >= quorumCount
 }
 
-func (f *failureDomainsQuorum) isNodeActive(ipDomain string) bool {
+// isDomainActive returns true if the input failure domains is a part of
+// of an active domain list
+func (f *failureDomainsQuorum) isDomainActive(ipDomain string) bool {
 	isActive, _ := f.activeMap[ipDomain]
 	if isActive == types.CLUSTER_DOMAIN_STATE_ACTIVE {
 		return true
 	}
 	return false
+}
+
+func (f *failureDomainsQuorum) IsDomainActive(inputDomain string) bool {
+	return f.isDomainActive(inputDomain)
 }
 
 func (f *failureDomainsQuorum) UpdateNumOfQuorumMembers(quorumMembersMap types.ClusterDomainsQuorumMembersMap) {


### PR DESCRIPTION
- In gossip.Start()
  - do not join the member list and do not gossip to other nodes if we are a part
  of inactive domain
- In gossip.UpdateClusterDomainActiveMap
  - if our state changed in this API, and our domain changed from inactive to active
  then join the member list and start gossiping to other nodes

- Do not mark a node suspect, if the node is already a part of inactive domain.

- In gossip.ExternalNodeLeave, mark the node offline if and only if we are a part of active domain.