### PR TITLE
Use net.SplitHostPort to split ip:port so that IPv6 addresses are han…

### DIFF
--- a/proto/gossip.go
+++ b/proto/gossip.go
@@ -83,6 +83,7 @@ func (g *GossiperImpl) Init(
 	// Memberlist Config setup
 	mlConf := ml.DefaultLANConfig()
 
+	// Use net.SplitHostPort which handles IPv6 addrs
 	ip, port, _ := net.SplitHostPort(ipPort)
 
 	port64, _ := strconv.ParseInt(port, 10, 64)

--- a/proto/gossip.go
+++ b/proto/gossip.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -84,8 +83,8 @@ func (g *GossiperImpl) Init(
 	// Memberlist Config setup
 	mlConf := ml.DefaultLANConfig()
 
-	s := strings.Split(ipPort, ":")
-	ip, port := s[0], s[1]
+	ip, port, _ := net.SplitHostPort(ipPort)
+
 	port64, _ := strconv.ParseInt(port, 10, 64)
 
 	// Memberlist conf Name is the name of the node
@@ -207,7 +206,12 @@ func (g *GossiperImpl) Ping(peerNode types.NodeId, addr string) (time.Duration, 
 		pingDuration time.Duration
 	)
 
-	ipPort := strings.Split(addr, ":")
+	addrHost, addrPort, err := net.SplitHostPort(addr)
+	if err != nil {
+		return pingDuration, err
+	}
+	ipPort := []string{addrHost, addrPort}
+
 	port, err := strconv.ParseInt(ipPort[1], 10, 64)
 	if err != nil {
 		return pingDuration, err


### PR DESCRIPTION
…dled correctly.

Signed-off-by: Jose Rivera <jose@portworx.com>

Use correct API to handle IPv6 addresses when parsing 'ip:host' string.
