### PR TITLE
PWX-21380: fix getLocalState

### DIFF
--- a/proto/gossip_store.go
+++ b/proto/gossip_store.go
@@ -436,7 +436,14 @@ func (s *GossipStoreImpl) convertFromBytes(buf []byte, msg interface{}) error {
 func (s *GossipStoreImpl) getLocalState() types.NodeInfoMap {
 	localCopy := make(types.NodeInfoMap)
 	for key, value := range s.nodeMap {
-		localCopy[key] = value
+		cp := *(&value)         // make a copy
+		if value.Value != nil { // also copy the inner maps
+			cp.Value = make(types.StoreMap)
+			for k2, v2 := range value.Value {
+				cp.Value[k2] = v2
+			}
+		}
+		localCopy[key] = cp
 	}
 	return localCopy
 }

--- a/proto/gossip_store_test.go
+++ b/proto/gossip_store_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/libopenstorage/gossip/types"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -390,4 +391,47 @@ func TestGossipStoreBlackBoxTests(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGetLocalState(t *testing.T) {
+	gs := &GossipStoreImpl{
+		nodeMap: types.NodeInfoMap{
+			"first": types.NodeInfo{
+				Id:           "first",
+				GenNumber:    1,
+				LastUpdateTs: time.Now(),
+				Value: types.StoreMap{
+					"first": "foo",
+				},
+			},
+			"second": types.NodeInfo{
+				Id:           "second",
+				GenNumber:    2,
+				LastUpdateTs: time.Now(),
+				Value: types.StoreMap{
+					"second": "bar",
+				},
+			},
+		},
+	}
+	// create a copy
+	aCopy := gs.getLocalState()
+
+	// insert some new fields into the copy
+	aCopy["third"] = types.NodeInfo{
+		Id:           "third",
+		GenNumber:    3,
+		LastUpdateTs: time.Now(),
+		Value: types.StoreMap{
+			"third": "pizza",
+		},
+	}
+	aCopy["second"].Value[`zz`] = "new value"
+
+	// ensure original did not get the new fields
+	assert.NotEmpty(t, gs.nodeMap["first"])
+	assert.Empty(t, gs.nodeMap["third"])
+	assert.NotEmpty(t, aCopy["third"])
+	assert.NotEmpty(t, aCopy["second"].Value[`zz`])
+	assert.Empty(t, gs.nodeMap["second"].Value[`zz`])
 }


### PR DESCRIPTION
* getLocalState() fixed to make a full copy of the NodeInfoMap

Signed-off-by: Zoran Rajic <zox@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Likely cause for `fatal error: concurrent map read and map write` errors with `GetLocalStateInBytes` and object encoding
* the `NodeInfo.Values` is an embedded map, which got copied as a reference (pointer)
* additions into the `NodeInfo.Values` map modified the original NodeInfoMap, as well as all the copies created via getLocalState()

**Which issue(s) this PR fixes** (optional)
Closes # PWX-21380

**Special notes for your reviewer**:

Note, was not able to reproduce the original issue