### PR TITLE
expose suspicion multiplier

### DIFF
--- a/proto/gossip.go
+++ b/proto/gossip.go
@@ -101,6 +101,7 @@ func (g *GossiperImpl) Init(
 	mlConf.GossipInterval = g.gossipInterval
 	// ProbeInterval used for broadcasts and decides probing behavior
 	mlConf.ProbeInterval = gossipIntervals.ProbeInterval
+	mlConf.SuspicionMult = gossipIntervals.SuspicionMult
 
 	// MemberDelegates
 	g.InitGossipDelegate(

--- a/proto/gossip_test.go
+++ b/proto/gossip_test.go
@@ -32,6 +32,7 @@ func newGossiperImpl(
 		ProbeInterval:    types.DEFAULT_PROBE_INTERVAL,
 		ProbeTimeout:     types.DEFAULT_PROBE_TIMEOUT,
 		QuorumTimeout:    TestQuorumTimeout,
+		SuspicionMult:    types.DEFAULT_SUSPICION_MULTIPLIER,
 	}
 	g.Init(ip, selfNodeId, 1, gi, version, clusterId, selfFailureDomain)
 	g.selfCorrect = false

--- a/types/types.go
+++ b/types/types.go
@@ -46,13 +46,14 @@ type ClusterDomainsQuorumMembersMap map[string]int
 // Constant Definitions
 
 const (
-	DEFAULT_GOSSIP_INTERVAL    time.Duration = 2 * time.Second
-	DEFAULT_PUSH_PULL_INTERVAL time.Duration = 2 * time.Second
-	DEFAULT_PROBE_INTERVAL     time.Duration = 5 * time.Second
-	DEFAULT_PROBE_TIMEOUT      time.Duration = 200 * time.Millisecond
-	DEFAULT_QUORUM_TIMEOUT     time.Duration = 1 * time.Minute
-	DEFAULT_GOSSIP_VERSION     string        = "v1"
-	GOSSIP_VERSION_2           string        = "v2"
+	DEFAULT_GOSSIP_INTERVAL      time.Duration = 2 * time.Second
+	DEFAULT_PUSH_PULL_INTERVAL   time.Duration = 2 * time.Second
+	DEFAULT_PROBE_INTERVAL       time.Duration = 5 * time.Second
+	DEFAULT_PROBE_TIMEOUT        time.Duration = 200 * time.Millisecond
+	DEFAULT_QUORUM_TIMEOUT       time.Duration = 1 * time.Minute
+	DEFAULT_SUSPICION_MULTIPLIER int           = 5
+	DEFAULT_GOSSIP_VERSION       string        = "v1"
+	GOSSIP_VERSION_2             string        = "v2"
 )
 
 const (
@@ -164,6 +165,9 @@ type GossipIntervals struct {
 	// QuorumTimeout is the timeout for which a node will stay in the SUSPECT_NOT_IN_QUORUM
 	// and then transition to NOT_IN_QUORUM (Not UP) if quorum is not satisfied
 	QuorumTimeout time.Duration
+	// SuspicionMult is the multiplier for determining the time an
+	// inaccessible node is considered suspect before declaring it dead.
+	SuspicionMult int
 }
 
 // GossipNodeConfiguration is the peer node configuration with which gossip on this


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow callers to specify the suspicion multiplier as part of the gossip intervals struct.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

